### PR TITLE
Advanced Loading > full implementation of unloading procedure

### DIFF
--- a/src/main/java/net/runeduniverse/libs/rogm/CoreSession.java
+++ b/src/main/java/net/runeduniverse/libs/rogm/CoreSession.java
@@ -279,4 +279,15 @@ public final class CoreSession implements Session {
 		for (Object e : entities)
 			this.delete(e);
 	}
+
+	@Override
+	public void unload(Object entity) {
+		this.buffer.removeEntry(entity);
+	}
+
+	@Override
+	public void unloadAll(Collection<Object> entities) {
+		for (Object object : entities)
+			this.unload(object);
+	}
 }

--- a/src/main/java/net/runeduniverse/libs/rogm/Session.java
+++ b/src/main/java/net/runeduniverse/libs/rogm/Session.java
@@ -49,6 +49,10 @@ public interface Session extends AutoCloseable {
 
 	void deleteAll(Collection<Object> entities);
 
+	void unload(Object entity);
+
+	void unloadAll(Collection<Object> entities);
+
 	public static Session create(Configuration cnf) throws Exception {
 		return new CoreSession(cnf);
 	}

--- a/src/test/java/net/runeduniverse/libs/rogm/SessionTest.java
+++ b/src/test/java/net/runeduniverse/libs/rogm/SessionTest.java
@@ -117,6 +117,10 @@ public class SessionTest extends ATest {
 		Player player = session.load(Player.class, UUID.fromString("12553411-d527-448d-b82b-33261e4f1618"));
 		assertNotNull("NO Entries in DB found", player);
 		System.out.println(player.toString());
+		session.save(player);
+		session.unload(player);
+		Player player2 = session.load(Player.class, UUID.fromString("12553411-d527-448d-b82b-33261e4f1618"));
+		assertFalse("Player did not get unloaded", player == player2);
 	}
 
 	@Test


### PR DESCRIPTION
closes #3 
includes:
+ ability to unload any node
>= no auto saving / no removal in other objects because it would force ROGM to delete the relation to this Node when the second Node gets saved