### PR TITLE
parsing bug fixed => deployed version 1.1.6

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,6 @@ We recommend using it in non-Spring projects!
 <dependency>
   <groupId>net.runeduniverse.libs</groupId>
   <artifactId>rogm</artifactId>
-  <version>1.1.5</version>
+  <version>1.1.6</version>
 </dependency>
 ```

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>net.runeduniverse.libs</groupId>
 	<artifactId>rogm</artifactId>
-	<version>1.1.5</version>
+	<version>1.1.6</version>
 
 	<name>ROGM</name>
 

--- a/src/main/java/net/runeduniverse/libs/rogm/parser/json/JSONParser.java
+++ b/src/main/java/net/runeduniverse/libs/rogm/parser/json/JSONParser.java
@@ -1,11 +1,14 @@
 package net.runeduniverse.libs.rogm.parser.json;
 
+import com.fasterxml.jackson.annotation.JsonAutoDetect.Visibility;
+import com.fasterxml.jackson.annotation.PropertyAccessor;
 import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.AnnotationIntrospector;
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.JsonMappingException;
+import com.fasterxml.jackson.databind.MapperFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.introspect.AnnotationIntrospectorPair;
 
@@ -21,6 +24,9 @@ public class JSONParser implements Parser {
 		MAPPER.configure(JsonGenerator.Feature.QUOTE_FIELD_NAMES, false);
 		MAPPER.configure(JsonParser.Feature.ALLOW_UNQUOTED_FIELD_NAMES, true);
 		MAPPER.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
+		MAPPER.configure(MapperFeature.AUTO_DETECT_GETTERS, false);
+		MAPPER.configure(MapperFeature.AUTO_DETECT_IS_GETTERS, false);
+		MAPPER.setVisibility(PropertyAccessor.FIELD, Visibility.ANY);
 	}
 
 	@Override

--- a/src/test/java/net/runeduniverse/libs/rogm/model/Person.java
+++ b/src/test/java/net/runeduniverse/libs/rogm/model/Person.java
@@ -31,6 +31,11 @@ public class Person extends AEntity {
 		this.fictional = fictional;
 	}
 
+	// this Getter must not be serialized
+	public Person getFriend() {
+		return new Person("Frank", "Nameless", true);
+	}
+
 	@PreSave
 	private void preSave() {
 		System.out.println("[PRE-SAVE] " + toString());

--- a/src/test/java/net/runeduniverse/libs/rogm/parser/JsonParserTest.java
+++ b/src/test/java/net/runeduniverse/libs/rogm/parser/JsonParserTest.java
@@ -4,7 +4,6 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 
 import java.util.Arrays;
-import org.junit.Before;
 import org.junit.Test;
 
 import net.runeduniverse.libs.rogm.ATest;
@@ -20,18 +19,19 @@ public class JsonParserTest extends ATest {
 		super(DatabaseType.Neo4j);
 	}
 
-	private House h0;
-	private House h1;
-	private House h2;
-	private City c;
+	private static House h0;
+	private static House h1;
+	private static House h2;
+	private static City c;
+	private static Person gray;
 
-	@Before
-	public void prepare() {
+	static {
 		Person marry = new Person("Marry", "Log", true);
 		Person frank = new Person("Frank", "Log", true);
 		Person georg = new Person("Georg", "Baker", true);
 		Person elma = new Person("Elma", "Light", true);
 		Person luna = new Person("Luna", "Moon", true);
+		gray = new Person("Gray", "Baker", true);
 
 		h0 = new House();
 		h0.setAddress(new Address("Bakersstreet", 12));
@@ -82,6 +82,12 @@ public class JsonParserTest extends ATest {
 		Person person = iParser.deserialize(Person.class, "{}");
 		System.out.println("Person is " + person);
 		assertNotNull("Person {} is null", person);
+	}
+
+	@Test
+	public void serialNoGetter() throws Exception {
+		String s = "{firstName:\"Gray\",lastName:\"Baker\",fictional:true}";
+		assertEquals(s, iParser.serialize(gray));
 	}
 
 }


### PR DESCRIPTION
closes #11 
Its seems until now the `JSONParser` ignored all `private` Variables and only serialized their Getters. The "new" and expected behavior serializes all variables not marked with `@Transient` and not their Getters.